### PR TITLE
release/v2.2.1-rc.1

### DIFF
--- a/src/core-unit/Unit.Tests/IAction/IAction.00.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.00.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction
+{
+    void Invoke();
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.01.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.01.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T>
+{
+    void Invoke(T arg);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.02.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.02.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2>
+{
+    void Invoke(T1 arg1, T2 arg2);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.03.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.03.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.04.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.04.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.05.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.05.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.06.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.06.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.07.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.07.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.08.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.08.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.09.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.09.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.10.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.10.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.11.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.11.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.12.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.12.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.13.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.13.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.14.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.14.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.15.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.15.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14, in T15>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15);
+}

--- a/src/core-unit/Unit.Tests/IAction/IAction.16.cs
+++ b/src/core-unit/Unit.Tests/IAction/IAction.16.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14, in T15, in T16>
+{
+    void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.00.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.00.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<out TResult>
+{
+    TResult Invoke();
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.01.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.01.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T, out TResult>
+{
+    TResult Invoke(T arg);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.02.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.02.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.03.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.03.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.04.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.04.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.05.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.05.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.06.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.06.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.07.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.07.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.08.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.08.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.09.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.09.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.10.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.10.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.11.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.11.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.12.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.12.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.13.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.13.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.14.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.14.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.15.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.15.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14, in T15, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15);
+}

--- a/src/core-unit/Unit.Tests/IFunc/IFunc.16.cs
+++ b/src/core-unit/Unit.Tests/IFunc/IFunc.16.cs
@@ -1,0 +1,6 @@
+namespace PrimeFuncPack.Core.Tests;
+
+public interface IFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, in T13, in T14, in T15, in T16, out TResult>
+{
+    TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16);
+}

--- a/src/core-unit/Unit.Tests/MockFuncFactory/MockActionFactory.cs
+++ b/src/core-unit/Unit.Tests/MockFuncFactory/MockActionFactory.cs
@@ -1,0 +1,125 @@
+﻿using Moq;
+
+namespace PrimeFuncPack.Core.Tests;
+
+internal static class MockActionFactory
+{
+    public static Mock<IAction> CreateMockAction()
+    {
+        Mock<IAction> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke());
+        return mock;
+    }
+
+    public static Mock<IAction<TSource>> CreateMockAction<TSource>()
+    {
+        Mock<IAction<TSource>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<TSource>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2>> CreateMockAction<T1, T2>()
+    {
+        Mock<IAction<T1, T2>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3>> CreateMockAction<T1, T2, T3>()
+    {
+        Mock<IAction<T1, T2, T3>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4>> CreateMockAction<T1, T2, T3, T4>()
+    {
+        Mock<IAction<T1, T2, T3, T4>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5>> CreateMockAction<T1, T2, T3, T4, T5>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6>> CreateMockAction<T1, T2, T3, T4, T5, T6>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>(), It.IsAny<T15>()));
+        return mock;
+    }
+
+    public static Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> CreateMockAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>()
+    {
+        Mock<IAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> mock = new(MockBehavior.Strict);
+        mock.Setup(action => action.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>(), It.IsAny<T15>(), It.IsAny<T16>()));
+        return mock;
+    }
+}

--- a/src/core-unit/Unit.Tests/MockFuncFactory/MockFuncFactory.cs
+++ b/src/core-unit/Unit.Tests/MockFuncFactory/MockFuncFactory.cs
@@ -1,0 +1,125 @@
+﻿using Moq;
+
+namespace PrimeFuncPack.Core.Tests;
+
+internal static class MockFuncFactory
+{
+    public static Mock<IFunc<TResult>> CreateMockFunc<TResult>(TResult result)
+    {
+        Mock<IFunc<TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke()).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<TSource, TResult>> CreateMockFunc<TSource, TResult>(TResult result)
+    {
+        Mock<IFunc<TSource, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<TSource>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, TResult>> CreateMockFunc<T1, T2, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, TResult>> CreateMockFunc<T1, T2, T3, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, TResult>> CreateMockFunc<T1, T2, T3, T4, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>(), It.IsAny<T15>())).Returns(result);
+        return mock;
+    }
+
+    public static Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>> CreateMockFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(TResult result)
+    {
+        Mock<IFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>> mock = new(MockBehavior.Strict);
+        mock.Setup(func => func.Invoke(It.IsAny<T1>(), It.IsAny<T2>(), It.IsAny<T3>(), It.IsAny<T4>(), It.IsAny<T5>(), It.IsAny<T6>(), It.IsAny<T7>(), It.IsAny<T8>(), It.IsAny<T9>(), It.IsAny<T10>(), It.IsAny<T11>(), It.IsAny<T12>(), It.IsAny<T13>(), It.IsAny<T14>(), It.IsAny<T15>(), It.IsAny<T16>())).Returns(result);
+        return mock;
+    }
+}

--- a/src/core-unit/Unit.Tests/Unit.Tests.csproj
+++ b/src/core-unit/Unit.Tests/Unit.Tests.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="PrimeFuncPack.UnitTest.Data" Version="3.0.0" />
-    <PackageReference Include="PrimeFuncPack.UnitTest.Moq" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeAsFuncAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Obsolete/InvokeThenToUnitAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeAsFunc.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Obsolete/InvokeThenToUnit.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeAsFuncValueAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Obsolete/InvokeThenToUnitValueAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.00.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
 using NUnit.Framework;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.01.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.02.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.03.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.04.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.05.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.06.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.07.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.08.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.09.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.10.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.11.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.12.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.13.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.14.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.15.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.16.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
-using PrimeFuncPack.UnitTest.Moq;
 using System;
 using System.Threading.Tasks;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit/Unit.csproj
+++ b/src/core-unit/Unit/Unit.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Core.Unit is a core library for .NET consisting of Unit type targeted for use in functional programming.</Description>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>PrimeFuncPack.Core.Unit</AssemblyName>
-    <Version>2.2.0</Version>
+    <Version>2.2.1-rc.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnit.cs
+++ b/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnit.cs
@@ -10,14 +10,17 @@ partial class UnitExtensions
     public static Unit InvokeThenToUnit(
         this Action action)
         =>
-        action.InvokeAsFunc();
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)));
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnit, error: true)]
     public static Unit InvokeThenToUnit<T>(
         this Action<T> action,
         T obj)
         =>
-        action.InvokeAsFunc(obj);
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
+            obj);
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnit, error: true)]
     public static Unit InvokeThenToUnit<T1, T2>(
@@ -25,7 +28,8 @@ partial class UnitExtensions
         T1 arg1,
         T2 arg2)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2);
 
@@ -36,7 +40,8 @@ partial class UnitExtensions
         T2 arg2,
         T3 arg3)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3);
@@ -49,7 +54,8 @@ partial class UnitExtensions
         T3 arg3,
         T4 arg4)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -64,7 +70,8 @@ partial class UnitExtensions
         T4 arg4,
         T5 arg5)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -81,7 +88,8 @@ partial class UnitExtensions
         T5 arg5,
         T6 arg6)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -100,7 +108,8 @@ partial class UnitExtensions
         T6 arg6,
         T7 arg7)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -121,7 +130,8 @@ partial class UnitExtensions
         T7 arg7,
         T8 arg8)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -144,7 +154,8 @@ partial class UnitExtensions
         T8 arg8,
         T9 arg9)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -169,7 +180,8 @@ partial class UnitExtensions
         T9 arg9,
         T10 arg10)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -196,7 +208,8 @@ partial class UnitExtensions
         T10 arg10,
         T11 arg11)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -225,7 +238,8 @@ partial class UnitExtensions
         T11 arg11,
         T12 arg12)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -256,7 +270,8 @@ partial class UnitExtensions
         T12 arg12,
         T13 arg13)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -289,7 +304,8 @@ partial class UnitExtensions
         T13 arg13,
         T14 arg14)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -324,7 +340,8 @@ partial class UnitExtensions
         T14 arg14,
         T15 arg15)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,
@@ -361,7 +378,8 @@ partial class UnitExtensions
         T15 arg15,
         T16 arg16)
         =>
-        action.InvokeAsFunc(
+        Unit.InternalInvoke(
+            action ?? throw new ArgumentNullException(nameof(action)),
             arg1,
             arg2,
             arg3,

--- a/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnitAsync.cs
+++ b/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnitAsync.cs
@@ -12,14 +12,17 @@ partial class UnitExtensions
     public static Task<Unit> InvokeThenToUnitAsync(
         this Func<Task> funcAsync)
         =>
-        funcAsync.InvokeAsFuncAsync();
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)));
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnitAsync, error: true)]
     public static Task<Unit> InvokeThenToUnitAsync<T>(
         this Func<T, Task> funcAsync,
         T obj)
         =>
-        funcAsync.InvokeAsFuncAsync(obj);
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
+            obj);
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnitAsync, error: true)]
     public static Task<Unit> InvokeThenToUnitAsync<T1, T2>(
@@ -27,7 +30,8 @@ partial class UnitExtensions
         T1 arg1,
         T2 arg2)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2);
 
@@ -38,7 +42,8 @@ partial class UnitExtensions
         T2 arg2,
         T3 arg3)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3);
@@ -51,7 +56,8 @@ partial class UnitExtensions
         T3 arg3,
         T4 arg4)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -66,7 +72,8 @@ partial class UnitExtensions
         T4 arg4,
         T5 arg5)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -83,7 +90,8 @@ partial class UnitExtensions
         T5 arg5,
         T6 arg6)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -102,7 +110,8 @@ partial class UnitExtensions
         T6 arg6,
         T7 arg7)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -123,7 +132,8 @@ partial class UnitExtensions
         T7 arg7,
         T8 arg8)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -146,7 +156,8 @@ partial class UnitExtensions
         T8 arg8,
         T9 arg9)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -171,7 +182,8 @@ partial class UnitExtensions
         T9 arg9,
         T10 arg10)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -198,7 +210,8 @@ partial class UnitExtensions
         T10 arg10,
         T11 arg11)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -227,7 +240,8 @@ partial class UnitExtensions
         T11 arg11,
         T12 arg12)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -258,7 +272,8 @@ partial class UnitExtensions
         T12 arg12,
         T13 arg13)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -291,7 +306,8 @@ partial class UnitExtensions
         T13 arg13,
         T14 arg14)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -326,7 +342,8 @@ partial class UnitExtensions
         T14 arg14,
         T15 arg15)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -363,7 +380,8 @@ partial class UnitExtensions
         T15 arg15,
         T16 arg16)
         =>
-        funcAsync.InvokeAsFuncAsync(
+        Unit.InternalInvokeAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,

--- a/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnitValueAsync.cs
+++ b/src/core-unit/Unit/UnitExtensions.Obsolete/Obsolete.InvokeThenToUnitValueAsync.cs
@@ -12,14 +12,17 @@ partial class UnitExtensions
     public static ValueTask<Unit> InvokeThenToUnitValueAsync(
         this Func<ValueTask> funcAsync)
         =>
-        funcAsync.InvokeAsFuncValueAsync();
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)));
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnitValueAsync, error: true)]
     public static ValueTask<Unit> InvokeThenToUnitValueAsync<T>(
         this Func<T, ValueTask> funcAsync,
         T obj)
         =>
-        funcAsync.InvokeAsFuncValueAsync(obj);
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
+            obj);
 
     [Obsolete(ObsoleteMessage_InvokeThenToUnitValueAsync, error: true)]
     public static ValueTask<Unit> InvokeThenToUnitValueAsync<T1, T2>(
@@ -27,7 +30,8 @@ partial class UnitExtensions
         T1 arg1,
         T2 arg2)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2);
 
@@ -38,7 +42,8 @@ partial class UnitExtensions
         T2 arg2,
         T3 arg3)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3);
@@ -51,7 +56,8 @@ partial class UnitExtensions
         T3 arg3,
         T4 arg4)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -66,7 +72,8 @@ partial class UnitExtensions
         T4 arg4,
         T5 arg5)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -83,7 +90,8 @@ partial class UnitExtensions
         T5 arg5,
         T6 arg6)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -102,7 +110,8 @@ partial class UnitExtensions
         T6 arg6,
         T7 arg7)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -123,7 +132,8 @@ partial class UnitExtensions
         T7 arg7,
         T8 arg8)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -146,7 +156,8 @@ partial class UnitExtensions
         T8 arg8,
         T9 arg9)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -171,7 +182,8 @@ partial class UnitExtensions
         T9 arg9,
         T10 arg10)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -198,7 +210,8 @@ partial class UnitExtensions
         T10 arg10,
         T11 arg11)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -227,7 +240,8 @@ partial class UnitExtensions
         T11 arg11,
         T12 arg12)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -258,7 +272,8 @@ partial class UnitExtensions
         T12 arg12,
         T13 arg13)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -291,7 +306,8 @@ partial class UnitExtensions
         T13 arg13,
         T14 arg14)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -326,7 +342,8 @@ partial class UnitExtensions
         T14 arg14,
         T15 arg15)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,
@@ -363,7 +380,8 @@ partial class UnitExtensions
         T15 arg15,
         T16 arg16)
         =>
-        funcAsync.InvokeAsFuncValueAsync(
+        Unit.InternalInvokeValueAsync(
+            funcAsync ?? throw new ArgumentNullException(nameof(funcAsync)),
             arg1,
             arg2,
             arg3,


### PR DESCRIPTION
- `Unit` tests:
-- Replace the deprecated `PrimeFuncPack.UnitTest.Moq`
- `Unit`:
-- Make the obsolete impl (`InvokeThenToUnit`) the same as the new (`InvokeAsFunc`) instead of the wrapping
-- v2.2.1-rc.1